### PR TITLE
add default co2 to 0 in recipe table

### DIFF
--- a/db/migrate/20241203112518_add_default_to_co2_recipe.rb
+++ b/db/migrate/20241203112518_add_default_to_co2_recipe.rb
@@ -1,0 +1,5 @@
+class AddDefaultToCo2Recipe < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :recipes, :co2, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_02_141417) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_03_112518) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -84,7 +84,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_02_141417) do
     t.integer "time"
     t.integer "difficulty"
     t.integer "cost"
-    t.integer "co2"
+    t.integer "co2", default: 0
     t.boolean "vegetal", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Pour éviter une erreur dans la génération des recettes, modification de la table Recipe, colonne Co2 default : 0